### PR TITLE
FLUID-6465: Relocate Nexus repositories to fluid-project

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ in Co-Occurrence Engine "recipes".
 Nexus with Co-Occurrence Engine
 -------------------------------
 
-This repository includes a grade, `gpii.nexus.nexusWithCoOccurrenceEngine`, and
+This repository includes a grade, `fluid.nexus.nexusWithCoOccurrenceEngine`, and
 runner script, `nexusWithCoOccurrenceEngine.js`, to run a Nexus instance with a
 Co-Occurrence Engine. To start such a Nexus instance:
 

--- a/configs/fluid.nexusWithCoOccurrenceEngine.config.json
+++ b/configs/fluid.nexusWithCoOccurrenceEngine.config.json
@@ -1,5 +1,5 @@
 {
-    "type": "gpii.nexusWithCoOccurrenceEngine.config",
+    "type": "fluid.nexusWithCoOccurrenceEngine.config",
     "options": {
         "serverPort": 9081,
         "components": {
@@ -10,7 +10,7 @@
                     "port": "{kettle.config}.options.serverPort",
                     "components": {
                         "nexus": {
-                            "type": "gpii.nexus.nexusWithCoOccurrenceEngine"
+                            "type": "fluid.nexus.nexusWithCoOccurrenceEngine"
                         }
                     }
                 }

--- a/documentation/CoOccurrenceEngine.md
+++ b/documentation/CoOccurrenceEngine.md
@@ -39,7 +39,7 @@ An example reactant entry:
     phSensor: {
         match: {
             type: "gradeMatcher",
-            gradeName: "gpii.nexus.atlasScientificDriver.phSensor"
+            gradeName: "fluid.nexus.atlasScientificDriver.phSensor"
         }
     }
 
@@ -57,7 +57,7 @@ An example product section:
     product: {
         path: "sendPhSensor",
         options: {
-            type: "gpii.nexus.scienceLab.sendPhSensor"
+            type: "fluid.nexus.scienceLab.sendPhSensor"
         }
     }
 
@@ -76,33 +76,33 @@ Sample Recipe and Product grades
 Recipe:
 
     {
-        gradeNames: [ "gpii.nexus.recipe" ],
+        gradeNames: [ "fluid.nexus.recipe" ],
         reactants: {
             phSensor: {
                 match: {
                     type: "gradeMatcher",
-                    gradeName: "gpii.nexus.atlasScientificDriver.phSensor"
+                    gradeName: "fluid.nexus.atlasScientificDriver.phSensor"
                 }
             },
             collector: {
                 match: {
                     type: "gradeMatcher",
-                    gradeName: "gpii.nexus.scienceLab.collector"
+                    gradeName: "fluid.nexus.scienceLab.collector"
                 }
             }
         },
         product: {
             path: "sendPhSensor",
             options: {
-                type: "gpii.nexus.scienceLab.sendPhSensor"
+                type: "fluid.nexus.scienceLab.sendPhSensor"
             }
         }
     }
 
-Grade defaults for the "gpii.nexus.scienceLab.sendPhSensor" product:
+Grade defaults for the "fluid.nexus.scienceLab.sendPhSensor" product:
 
     {
-        gradeNames: [ "gpii.nexus.recipeProduct" ],
+        gradeNames: [ "fluid.nexus.recipeProduct" ],
         componentPaths: {
             phSensor: null,
             collector: null

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */

--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@ https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICE
 
 var fluid = require("infusion");
 
-fluid.module.register("gpii-co-occurrence-engine", __dirname, require);
+fluid.module.register("co-occurrence-engine", __dirname, require);
 require("./src/CoOccurrenceEngine.js");
 require("./src/NexusWithCoOccurrenceEngine.js");

--- a/nexusWithCoOccurrenceEngine.js
+++ b/nexusWithCoOccurrenceEngine.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */

--- a/nexusWithCoOccurrenceEngine.js
+++ b/nexusWithCoOccurrenceEngine.js
@@ -17,6 +17,6 @@ var kettle = require("kettle");
 require("./index.js");
 
 kettle.config.loadConfig({
-    configName: kettle.config.getConfigName("gpii.nexusWithCoOccurrenceEngine.config"),
-    configPath: kettle.config.getConfigPath("%gpii-co-occurrence-engine/configs")
+    configName: kettle.config.getConfigName("fluid.nexusWithCoOccurrenceEngine.config"),
+    configPath: kettle.config.getConfigPath("%co-occurrence-engine/configs")
 });

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
-    "name": "gpii-co-occurrence-engine",
+    "name": "co-occurrence-engine",
     "version": "0.1.0",
-    "author": "GPII",
+    "author": "fluid-project",
     "license": "BSD-3-Clause",
-    "repository": "git@github.com:GPII/co-occurrence-engine.git",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/fluid-project/co-occurrence-engine.git"
+    },
     "scripts": {
         "test": "node tests/all-tests.js"
     },
     "dependencies": {
-        "gpii-nexus": "simonbates/nexus#GPII-2488",
+        "infusion-nexus": "fluid-project/infusion-nexus#0.2.0",
         "infusion": "2.0.0",
         "kettle": "1.1.1"
     },

--- a/src/CoOccurrenceEngine.js
+++ b/src/CoOccurrenceEngine.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */
@@ -15,7 +15,7 @@ https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
 var fluid = require("infusion"),
     gpii = fluid.registerNamespace("gpii");
 
-fluid.require("gpii-nexus");
+fluid.require("infusion-nexus");
 
 fluid.defaults("gpii.nexus.recipe", {
     gradeNames: "fluid.component"

--- a/src/CoOccurrenceEngine.js
+++ b/src/CoOccurrenceEngine.js
@@ -17,19 +17,19 @@ var fluid = require("infusion"),
 
 fluid.require("infusion-nexus");
 
-fluid.defaults("gpii.nexus.recipe", {
+fluid.defaults("fluid.nexus.recipe", {
     gradeNames: "fluid.component"
 });
 
-fluid.defaults("gpii.nexus.recipeProduct", {
+fluid.defaults("fluid.nexus.recipeProduct", {
     gradeNames: "fluid.modelComponent"
 });
 
-fluid.defaults("gpii.nexus.recipeMatcher", {
+fluid.defaults("fluid.nexus.recipeMatcher", {
     gradeNames: "fluid.component",
     invokers: {
         matchRecipe: {
-            funcName: "gpii.nexus.recipeMatcher.matchRecipe",
+            funcName: "fluid.nexus.recipeMatcher.matchRecipe",
             args: [
                 "{arguments}.0", // recipe to test
                 "{arguments}.1"  // array of components
@@ -38,12 +38,12 @@ fluid.defaults("gpii.nexus.recipeMatcher", {
     }
 });
 
-gpii.nexus.recipeMatcher.matchRecipe = function (recipe, components) {
+fluid.nexus.recipeMatcher.matchRecipe = function (recipe, components) {
     var matchedReactants = {};
     var foundAllReactants = true;
     fluid.each(recipe.options.reactants, function (reactant, reactantName) {
         var foundReactant = fluid.find(components, function (component) {
-            if (gpii.nexus.recipeMatcher.componentMatchesReactantSpec(component, reactant.match)) {
+            if (fluid.nexus.recipeMatcher.componentMatchesReactantSpec(component, reactant.match)) {
                 matchedReactants[reactantName] = component;
                 return true;
             }
@@ -69,23 +69,23 @@ gpii.nexus.recipeMatcher.matchRecipe = function (recipe, components) {
 //
 // https://github.com/fluid-project/infusion/blob/master/src/framework/core/js/FluidIoC.js#L322
 
-gpii.nexus.recipeMatcher.componentMatchesReactantSpec = function (component, matchRules) {
+fluid.nexus.recipeMatcher.componentMatchesReactantSpec = function (component, matchRules) {
     if (matchRules.type === "gradeMatcher") {
         return fluid.componentHasGrade(component, matchRules.gradeName);
     }
 };
 
-// gpii.nexus.componentRootHolder and gpii.nexus.componentRoot are marker grades
+// fluid.nexus.componentRootHolder and fluid.nexus.componentRoot are marker grades
 // used by the Co-Occurrence Engine distributeOptions rules. A Co-Occurrence
 // Engine must be deployed under an ancestor with the grade
-// gpii.nexus.componentRootHolder. And the component root must be a descendant
+// fluid.nexus.componentRootHolder. And the component root must be a descendant
 // of the componentRootHolder.
 
-fluid.defaults("gpii.nexus.componentRootHolder", {
+fluid.defaults("fluid.nexus.componentRootHolder", {
     gradeNames: ["fluid.component"]
 });
 
-fluid.defaults("gpii.nexus.componentRoot", {
+fluid.defaults("fluid.nexus.componentRoot", {
     gradeNames: ["fluid.component"]
 });
 
@@ -93,7 +93,7 @@ fluid.defaults("gpii.nexus.componentRoot", {
 //       - Configured in each recipe; or
 //       - Randomly assigned by the Co-Occurrence Engine
 
-fluid.defaults("gpii.nexus.coOccurrenceEngine", {
+fluid.defaults("fluid.nexus.coOccurrenceEngine", {
     gradeNames: ["fluid.component"],
     members: {
         // TODO: Is "members" the best place for this map?
@@ -106,14 +106,14 @@ fluid.defaults("gpii.nexus.coOccurrenceEngine", {
     },
     components: {
         componentRoot: null, // To be provided by integrators
-        recipesContainer: "{gpii.nexus.coOccurrenceEngine}.componentRoot.recipes",
+        recipesContainer: "{fluid.nexus.coOccurrenceEngine}.componentRoot.recipes",
         recipeMatcher: {
-            type: "gpii.nexus.recipeMatcher"
+            type: "fluid.nexus.recipeMatcher"
         }
     },
     invokers: {
         getRecipes: {
-            funcName: "gpii.nexus.coOccurrenceEngine.getRecipes",
+            funcName: "fluid.nexus.coOccurrenceEngine.getRecipes",
             args: ["{that}.recipesContainer"]
         }
     },
@@ -123,7 +123,7 @@ fluid.defaults("gpii.nexus.coOccurrenceEngine", {
     },
     listeners: {
         onComponentCreated: {
-            funcName: "gpii.nexus.coOccurrenceEngine.componentCreated",
+            funcName: "fluid.nexus.coOccurrenceEngine.componentCreated",
             args: [
                 "{that}.componentRoot",
                 "{that}.recipeMatcher",
@@ -132,7 +132,7 @@ fluid.defaults("gpii.nexus.coOccurrenceEngine", {
             ]
         },
         onComponentDestroyed: {
-            funcName: "gpii.nexus.coOccurrenceEngine.componentDestroyed",
+            funcName: "fluid.nexus.coOccurrenceEngine.componentDestroyed",
             args: [
                 "{that}.componentRoot",
                 "{that}.reactantRecipeMembership",
@@ -142,30 +142,30 @@ fluid.defaults("gpii.nexus.coOccurrenceEngine", {
     },
     distributeOptions: [
         {
-            target: "{gpii.nexus.componentRootHolder gpii.nexus.componentRoot fluid.component}.options.listeners",
+            target: "{fluid.nexus.componentRootHolder fluid.nexus.componentRoot fluid.component}.options.listeners",
             record: {
                 "onCreate.fireCoOccurrenceEngineComponentCreated":
-                    "{gpii.nexus.coOccurrenceEngine}.events.onComponentCreated",
+                    "{fluid.nexus.coOccurrenceEngine}.events.onComponentCreated",
                 "afterDestroy.fireCoOccurrenceEngineComponentDestroyed":
-                    "{gpii.nexus.coOccurrenceEngine}.events.onComponentDestroyed"
+                    "{fluid.nexus.coOccurrenceEngine}.events.onComponentDestroyed"
             },
             namespace: "coOccurrenceEngine"
         }
     ]
 });
 
-gpii.nexus.coOccurrenceEngine.getRecipes = function (recipesContainer) {
+fluid.nexus.coOccurrenceEngine.getRecipes = function (recipesContainer) {
     var recipes = [];
     fluid.each(recipesContainer, function (recipe) {
         if (fluid.isComponent(recipe)
-                && fluid.componentHasGrade(recipe, "gpii.nexus.recipe")) {
+                && fluid.componentHasGrade(recipe, "fluid.nexus.recipe")) {
             recipes.push(recipe);
         }
     });
     return recipes;
 };
 
-gpii.nexus.coOccurrenceEngine.componentCreated = function (componentRoot, recipeMatcher, recipes, reactantRecipeMembership) {
+fluid.nexus.coOccurrenceEngine.componentCreated = function (componentRoot, recipeMatcher, recipes, reactantRecipeMembership) {
     var components = [];
 
     // TODO: This will only collect direct children of componentRoot, do we want all descendants?
@@ -210,7 +210,7 @@ gpii.nexus.coOccurrenceEngine.componentCreated = function (componentRoot, recipe
     }
 };
 
-gpii.nexus.coOccurrenceEngine.componentDestroyed = function (componentRoot, reactantRecipeMembership, destroyedComponentId) {
+fluid.nexus.coOccurrenceEngine.componentDestroyed = function (componentRoot, reactantRecipeMembership, destroyedComponentId) {
     var parentPaths = reactantRecipeMembership[destroyedComponentId];
     fluid.each(parentPaths, function (parentPath) {
         gpii.nexus.destroyInContainer(componentRoot, parentPath);

--- a/src/NexusWithCoOccurrenceEngine.js
+++ b/src/NexusWithCoOccurrenceEngine.js
@@ -16,11 +16,11 @@ var fluid = require("infusion");
 
 fluid.require("%infusion-nexus");
 
-fluid.defaults("gpii.nexus.nexusWithCoOccurrenceEngine", {
-    gradeNames: ["gpii.nexus", "gpii.nexus.componentRootHolder"],
+fluid.defaults("fluid.nexus.nexusWithCoOccurrenceEngine", {
+    gradeNames: ["gpii.nexus", "fluid.nexus.componentRootHolder"],
     components: {
         nexusComponentRoot: {
-            type: "gpii.nexus.componentRoot",
+            type: "fluid.nexus.componentRoot",
             options: {
                 components: {
                     recipes: {
@@ -30,7 +30,7 @@ fluid.defaults("gpii.nexus.nexusWithCoOccurrenceEngine", {
             }
         },
         coOccurrenceEngine: {
-            type: "gpii.nexus.coOccurrenceEngine",
+            type: "fluid.nexus.coOccurrenceEngine",
             options: {
                 components: {
                     componentRoot: "{nexusWithCoOccurrenceEngine}.nexusComponentRoot"

--- a/src/NexusWithCoOccurrenceEngine.js
+++ b/src/NexusWithCoOccurrenceEngine.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */
@@ -14,7 +14,7 @@ https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
 
 var fluid = require("infusion");
 
-fluid.require("%gpii-nexus");
+fluid.require("%infusion-nexus");
 
 fluid.defaults("gpii.nexus.nexusWithCoOccurrenceEngine", {
     gradeNames: ["gpii.nexus", "gpii.nexus.componentRootHolder"],

--- a/src/test/RecipeTestGrades.js
+++ b/src/test/RecipeTestGrades.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */

--- a/src/test/RecipeTestGrades.js
+++ b/src/test/RecipeTestGrades.js
@@ -14,22 +14,22 @@ https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICE
 
 var fluid = require("infusion");
 
-fluid.defaults("gpii.test.nexus.reactantA", {
+fluid.defaults("fluid.test.nexus.reactantA", {
     gradeNames: ["fluid.modelComponent"],
     model: {
         valueA: 10
     }
 });
 
-fluid.defaults("gpii.test.nexus.reactantB", {
+fluid.defaults("fluid.test.nexus.reactantB", {
     gradeNames: ["fluid.modelComponent"],
     model: {
         valueB: 20
     }
 });
 
-fluid.defaults("gpii.test.nexus.recipeX.product", {
-    gradeNames: ["gpii.nexus.recipeProduct"],
+fluid.defaults("fluid.test.nexus.recipeX.product", {
+    gradeNames: ["fluid.nexus.recipeProduct"],
     componentPaths: {
         componentA: null,
         componentB: null
@@ -53,32 +53,32 @@ fluid.defaults("gpii.test.nexus.recipeX.product", {
     ]
 });
 
-fluid.defaults("gpii.test.nexus.recipeX", {
-    gradeNames: ["gpii.nexus.recipe"],
+fluid.defaults("fluid.test.nexus.recipeX", {
+    gradeNames: ["fluid.nexus.recipe"],
     reactants: {
         componentA: {
             match: {
                 type: "gradeMatcher",
-                gradeName: "gpii.test.nexus.reactantA"
+                gradeName: "fluid.test.nexus.reactantA"
             }
         },
         componentB: {
             match: {
                 type: "gradeMatcher",
-                gradeName: "gpii.test.nexus.reactantB"
+                gradeName: "fluid.test.nexus.reactantB"
             }
         }
     },
     product: {
         path: "recipeXProduct",
         options: {
-            type: "gpii.test.nexus.recipeX.product"
+            type: "fluid.test.nexus.recipeX.product"
         }
     }
 });
 
-fluid.defaults("gpii.test.nexus.recipeY.product", {
-    gradeNames: ["gpii.nexus.recipeProduct"],
+fluid.defaults("fluid.test.nexus.recipeY.product", {
+    gradeNames: ["fluid.nexus.recipeProduct"],
     componentPaths: {
         componentA: null
     },
@@ -87,20 +87,20 @@ fluid.defaults("gpii.test.nexus.recipeY.product", {
     }
 });
 
-fluid.defaults("gpii.test.nexus.recipeY", {
-    gradeNames: ["gpii.nexus.recipe"],
+fluid.defaults("fluid.test.nexus.recipeY", {
+    gradeNames: ["fluid.nexus.recipe"],
     reactants: {
         componentA: {
             match: {
                 type: "gradeMatcher",
-                gradeName: "gpii.test.nexus.reactantA"
+                gradeName: "fluid.test.nexus.reactantA"
             }
         }
     },
     product: {
         path: "recipeYProduct",
         options: {
-            type: "gpii.test.nexus.recipeY.product"
+            type: "fluid.test.nexus.recipeY.product"
         }
     }
 });

--- a/src/test/TestUtils.js
+++ b/src/test/TestUtils.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */

--- a/src/test/TestUtils.js
+++ b/src/test/TestUtils.js
@@ -12,12 +12,11 @@ https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICE
 
 "use strict";
 
-var fluid = require("infusion"),
-    gpii = fluid.registerNamespace("gpii");
+var fluid = require("infusion");
 
-fluid.registerNamespace("gpii.tests.nexus.coOccurrenceEngine");
+fluid.registerNamespace("fluid.tests.nexus.coOccurrenceEngine");
 
-gpii.tests.nexus.coOccurrenceEngine.fireComponentGradeEvent = function (component, gradeEvents) {
+fluid.tests.nexus.coOccurrenceEngine.fireComponentGradeEvent = function (component, gradeEvents) {
     fluid.each(gradeEvents, function (event, grade) {
         if (fluid.componentHasGrade(component, grade)) {
             event.fire(component);

--- a/tests/CoOccurrenceEngineTests.js
+++ b/tests/CoOccurrenceEngineTests.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */

--- a/tests/CoOccurrenceEngineTests.js
+++ b/tests/CoOccurrenceEngineTests.js
@@ -22,11 +22,11 @@ require("../src/test/TestUtils.js");
 
 // Base testEnvironment
 
-fluid.defaults("gpii.tests.nexus.coOccurrenceEngineTestEnvironment", {
-    gradeNames: ["fluid.test.testEnvironment", "gpii.nexus.componentRootHolder"],
+fluid.defaults("fluid.tests.nexus.coOccurrenceEngineTestEnvironment", {
+    gradeNames: ["fluid.test.testEnvironment", "fluid.nexus.componentRootHolder"],
     components: {
         componentRoot: {
-            type: "gpii.nexus.componentRoot",
+            type: "fluid.nexus.componentRoot",
             options: {
                 components: {
                     recipes: {
@@ -36,29 +36,29 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineTestEnvironment", {
             }
         },
         coOccurrenceEngine : {
-            type: "gpii.nexus.coOccurrenceEngine",
+            type: "fluid.nexus.coOccurrenceEngine",
             options: {
                 components: {
                     componentRoot: "{coOccurrenceEngineTestEnvironment}.componentRoot"
                 },
                 listeners: {
                     onComponentCreated: {
-                        funcName: "gpii.tests.nexus.coOccurrenceEngine.fireComponentGradeEvent",
+                        funcName: "fluid.tests.nexus.coOccurrenceEngine.fireComponentGradeEvent",
                         args: [
                             "{arguments}.0",
                             {
-                                "gpii.test.nexus.recipeX.product": "{coOccurrenceEngineTestEnvironment}.events.onRecipeXProductCreated",
-                                "gpii.test.nexus.recipeY.product": "{coOccurrenceEngineTestEnvironment}.events.onRecipeYProductCreated"
+                                "fluid.test.nexus.recipeX.product": "{coOccurrenceEngineTestEnvironment}.events.onRecipeXProductCreated",
+                                "fluid.test.nexus.recipeY.product": "{coOccurrenceEngineTestEnvironment}.events.onRecipeYProductCreated"
                             }
                         ]
                     },
                     onComponentDestroyed: {
-                        funcName: "gpii.tests.nexus.coOccurrenceEngine.fireComponentGradeEvent",
+                        funcName: "fluid.tests.nexus.coOccurrenceEngine.fireComponentGradeEvent",
                         args: [
                             "{arguments}.0",
                             {
-                                "gpii.test.nexus.recipeX.product": "{coOccurrenceEngineTestEnvironment}.events.onRecipeXProductDestroyed",
-                                "gpii.test.nexus.recipeY.product": "{coOccurrenceEngineTestEnvironment}.events.onRecipeYProductDestroyed"
+                                "fluid.test.nexus.recipeX.product": "{coOccurrenceEngineTestEnvironment}.events.onRecipeXProductDestroyed",
+                                "fluid.test.nexus.recipeY.product": "{coOccurrenceEngineTestEnvironment}.events.onRecipeYProductDestroyed"
                             }
                         ]
                     }
@@ -90,16 +90,16 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineTestEnvironment", {
 
 // Tests
 
-fluid.defaults("gpii.tests.nexus.coOccurrenceEngineConstructionTests", {
-    gradeNames: ["gpii.tests.nexus.coOccurrenceEngineTestEnvironment"],
+fluid.defaults("fluid.tests.nexus.coOccurrenceEngineConstructionTests", {
+    gradeNames: ["fluid.tests.nexus.coOccurrenceEngineTestEnvironment"],
     components: {
         coOccurrenceEngineConstructionTester: {
-            type: "gpii.tests.nexus.coOccurrenceEngineConstructionTester"
+            type: "fluid.tests.nexus.coOccurrenceEngineConstructionTester"
         }
     }
 });
 
-fluid.defaults("gpii.tests.nexus.coOccurrenceEngineConstructionTester", {
+fluid.defaults("fluid.tests.nexus.coOccurrenceEngineConstructionTester", {
     gradeNames: ["fluid.test.testCaseHolder"],
     modules: [ {
         name: "Nexus Co-Occurrence Engine construction tests",
@@ -115,7 +115,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineConstructionTester", {
                             "{coOccurrenceEngine}.componentRoot",
                             "recipes.recipeX",
                             {
-                                type: "gpii.test.nexus.recipeX"
+                                type: "fluid.test.nexus.recipeX"
                             }
                         ]
                     },
@@ -136,7 +136,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineConstructionTester", {
                             "{coOccurrenceEngine}.componentRoot",
                             "reactantA",
                             {
-                                type: "gpii.test.nexus.reactantA"
+                                type: "fluid.test.nexus.reactantA"
                             }
                         ]
                     },
@@ -146,7 +146,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineConstructionTester", {
                             "{coOccurrenceEngine}.componentRoot",
                             "reactantB",
                             {
-                                type: "gpii.test.nexus.reactantB"
+                                type: "fluid.test.nexus.reactantB"
                             }
                         ]
                     },
@@ -207,7 +207,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineConstructionTester", {
                             "{coOccurrenceEngine}.componentRoot",
                             "anotherReactantA",
                             {
-                                type: "gpii.test.nexus.reactantA"
+                                type: "fluid.test.nexus.reactantA"
                             }
                         ]
                     },
@@ -239,16 +239,16 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineConstructionTester", {
     } ]
 });
 
-fluid.defaults("gpii.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTests", {
-    gradeNames: ["gpii.tests.nexus.coOccurrenceEngineTestEnvironment"],
+fluid.defaults("fluid.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTests", {
+    gradeNames: ["fluid.tests.nexus.coOccurrenceEngineTestEnvironment"],
     components: {
         coOccurrenceEngineReactantInMultipleProductsTester: {
-            type: "gpii.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTester"
+            type: "fluid.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTester"
         }
     }
 });
 
-fluid.defaults("gpii.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTester", {
+fluid.defaults("fluid.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTester", {
     gradeNames: ["fluid.test.testCaseHolder"],
     modules: [ {
         name: "Nexus Co-Occurrence Engine reactant in multiple products tests",
@@ -264,7 +264,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTes
                             "{coOccurrenceEngine}.componentRoot",
                             "recipes.recipeX",
                             {
-                                type: "gpii.test.nexus.recipeX"
+                                type: "fluid.test.nexus.recipeX"
                             }
                         ]
                     },
@@ -274,7 +274,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTes
                             "{coOccurrenceEngine}.componentRoot",
                             "recipes.recipeY",
                             {
-                                type: "gpii.test.nexus.recipeY"
+                                type: "fluid.test.nexus.recipeY"
                             }
                         ]
                     },
@@ -301,7 +301,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTes
                             "{coOccurrenceEngine}.componentRoot",
                             "reactantB",
                             {
-                                type: "gpii.test.nexus.reactantB"
+                                type: "fluid.test.nexus.reactantB"
                             }
                         ]
                     },
@@ -311,7 +311,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTes
                             "{coOccurrenceEngine}.componentRoot",
                             "reactantA",
                             {
-                                type: "gpii.test.nexus.reactantA"
+                                type: "fluid.test.nexus.reactantA"
                             }
                         ]
                     },
@@ -346,16 +346,16 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTes
     } ]
 });
 
-fluid.defaults("gpii.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTests", {
-    gradeNames: ["gpii.tests.nexus.coOccurrenceEngineTestEnvironment"],
+fluid.defaults("fluid.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTests", {
+    gradeNames: ["fluid.tests.nexus.coOccurrenceEngineTestEnvironment"],
     components: {
         coOccurrenceEngineRecipeAfterReactantsTester: {
-            type: "gpii.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTester"
+            type: "fluid.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTester"
         }
     }
 });
 
-fluid.defaults("gpii.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTester", {
+fluid.defaults("fluid.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTester", {
     gradeNames: ["fluid.test.testCaseHolder"],
     modules: [ {
         name: "Nexus Co-Occurrence Engine add recipe after reactants tests",
@@ -371,7 +371,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTester", 
                             "{coOccurrenceEngine}.componentRoot",
                             "reactantA",
                             {
-                                type: "gpii.test.nexus.reactantA"
+                                type: "fluid.test.nexus.reactantA"
                             }
                         ]
                     },
@@ -381,7 +381,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTester", 
                             "{coOccurrenceEngine}.componentRoot",
                             "reactantB",
                             {
-                                type: "gpii.test.nexus.reactantB"
+                                type: "fluid.test.nexus.reactantB"
                             }
                         ]
                     },
@@ -400,7 +400,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTester", 
                             "{coOccurrenceEngine}.componentRoot",
                             "recipes.recipeX",
                             {
-                                type: "gpii.test.nexus.recipeX"
+                                type: "fluid.test.nexus.recipeX"
                             }
                         ]
                     },
@@ -419,7 +419,7 @@ fluid.defaults("gpii.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTester", 
 });
 
 fluid.test.runTests([
-    "gpii.tests.nexus.coOccurrenceEngineConstructionTests",
-    "gpii.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTests",
-    "gpii.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTests"
+    "fluid.tests.nexus.coOccurrenceEngineConstructionTests",
+    "fluid.tests.nexus.coOccurrenceEngineReactantInMultipleProductsTests",
+    "fluid.tests.nexus.coOccurrenceEngineRecipeAfterReactantsTests"
 ]);

--- a/tests/NexusWithCoOccurrenceEngineTests.js
+++ b/tests/NexusWithCoOccurrenceEngineTests.js
@@ -13,8 +13,7 @@ https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICE
 "use strict";
 
 var fluid = require("infusion"),
-    kettle = require("kettle"),
-    gpii = fluid.registerNamespace("gpii");
+    kettle = require("kettle");
 
 require("../index.js");
 // TODO: Is using NexusTestUtils.js reasonable?
@@ -24,11 +23,11 @@ require("../src/test/TestUtils.js");
 
 kettle.loadTestingSupport();
 
-fluid.registerNamespace("gpii.tests.nexus.nexusWithCoOccurrenceEngine");
+fluid.registerNamespace("fluid.tests.nexus.nexusWithCoOccurrenceEngine");
 
 // Tests
 
-gpii.tests.nexus.nexusWithCoOccurrenceEngine.testDefs = [
+fluid.tests.nexus.nexusWithCoOccurrenceEngine.testDefs = [
     {
         name: "Add Recipe, construct reactants, and verify product created",
         gradeNames: "kettle.test.testCaseHolder",
@@ -37,8 +36,8 @@ gpii.tests.nexus.nexusWithCoOccurrenceEngine.testDefs = [
         },
         expect: 6,
         config: {
-            configName: "gpii.tests.nexusWithCoOccurrenceEngine.config",
-            configPath: "%gpii-co-occurrence-engine/tests/configs"
+            configName: "fluid.tests.nexusWithCoOccurrenceEngine.config",
+            configPath: "%co-occurrence-engine/tests/configs"
         },
         components: {
             addRecipeRequest: {
@@ -84,7 +83,7 @@ gpii.tests.nexus.nexusWithCoOccurrenceEngine.testDefs = [
             // Add our recipe
             {
                 func: "{addRecipeRequest}.send",
-                args: [{ type: "gpii.test.nexus.recipeX" }]
+                args: [{ type: "fluid.test.nexus.recipeX" }]
             },
             {
                 event: "{addRecipeRequest}.events.onComplete",
@@ -95,7 +94,7 @@ gpii.tests.nexus.nexusWithCoOccurrenceEngine.testDefs = [
             // created
             {
                 func: "{constructReactantARequest}.send",
-                args: [{ type: "gpii.test.nexus.reactantA" }]
+                args: [{ type: "fluid.test.nexus.reactantA" }]
             },
             {
                 event: "{constructReactantARequest}.events.onComplete",
@@ -104,14 +103,14 @@ gpii.tests.nexus.nexusWithCoOccurrenceEngine.testDefs = [
             },
             {
                 func: "{constructReactantBRequest}.send",
-                args: [{ type: "gpii.test.nexus.reactantB" }]
+                args: [{ type: "fluid.test.nexus.reactantB" }]
             },
             {
-                event: "{gpii.tests.nexus.nexusWithCoOccurrenceEngine}.events.onRecipeXProductCreated",
+                event: "{fluid.tests.nexus.nexusWithCoOccurrenceEngine}.events.onRecipeXProductCreated",
                 listener: "jqUnit.assertValue",
                 args: [
                     "Recipe X product created",
-                    "{gpii.tests.nexus.nexusWithCoOccurrenceEngine}.nexusComponentRoot.recipeXProduct"
+                    "{fluid.tests.nexus.nexusWithCoOccurrenceEngine}.nexusComponentRoot.recipeXProduct"
                 ]
             },
             {
@@ -166,4 +165,4 @@ gpii.tests.nexus.nexusWithCoOccurrenceEngine.testDefs = [
     }
 ];
 
-kettle.test.bootstrapServer(gpii.tests.nexus.nexusWithCoOccurrenceEngine.testDefs);
+kettle.test.bootstrapServer(fluid.tests.nexus.nexusWithCoOccurrenceEngine.testDefs);

--- a/tests/NexusWithCoOccurrenceEngineTests.js
+++ b/tests/NexusWithCoOccurrenceEngineTests.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */
@@ -18,7 +18,7 @@ var fluid = require("infusion"),
 
 require("../index.js");
 // TODO: Is using NexusTestUtils.js reasonable?
-fluid.require("%gpii-nexus/src/test/NexusTestUtils.js");
+fluid.require("%infusion-nexus/src/test/NexusTestUtils.js");
 require("../src/test/RecipeTestGrades.js");
 require("../src/test/TestUtils.js");
 

--- a/tests/RecipeMatcherTests.js
+++ b/tests/RecipeMatcherTests.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */

--- a/tests/RecipeMatcherTests.js
+++ b/tests/RecipeMatcherTests.js
@@ -13,19 +13,18 @@ https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICE
 "use strict";
 
 var fluid = require("infusion"),
-    gpii = fluid.registerNamespace("gpii"),
     jqUnit = fluid.require("node-jqunit");
 
 require("../index.js");
 
-fluid.defaults("gpii.tests.nexus.reactantA", {
+fluid.defaults("fluid.tests.nexus.reactantA", {
     gradeNames: "fluid.modelComponent"
 });
 
 jqUnit.test("RecipeMatcher Test", function () {
     jqUnit.expect(2);
 
-    var matcher = gpii.nexus.recipeMatcher();
+    var matcher = fluid.nexus.recipeMatcher();
 
     var recipe = {
         options: {
@@ -33,7 +32,7 @@ jqUnit.test("RecipeMatcher Test", function () {
                 componentA: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.tests.nexus.reactantA"
+                        gradeName: "fluid.tests.nexus.reactantA"
                     }
                 }
             }
@@ -45,7 +44,7 @@ jqUnit.test("RecipeMatcher Test", function () {
 
     // Recipe matches against an instance of reactantA
     var components = [
-        gpii.tests.nexus.reactantA()
+        fluid.tests.nexus.reactantA()
     ];
     jqUnit.assertEquals("Matches recipe", components[0], matcher.matchRecipe(recipe, components).componentA);
 });

--- a/tests/RecipeProductWiringTests.js
+++ b/tests/RecipeProductWiringTests.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */

--- a/tests/RecipeProductWiringTests.js
+++ b/tests/RecipeProductWiringTests.js
@@ -17,36 +17,35 @@ https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICE
 
 "use strict";
 
-var fluid = require("infusion"),
-    gpii = fluid.registerNamespace("gpii");
+var fluid = require("infusion");
 
 fluid.require("node-jqunit");
 
 require("../index.js");
 require("../src/test/RecipeTestGrades.js");
 
-fluid.registerNamespace("gpii.test.nexus");
+fluid.registerNamespace("fluid.test.nexus");
 
-gpii.test.nexus.changeModelAtPath = function (componentPath, modelPath, value) {
+fluid.test.nexus.changeModelAtPath = function (componentPath, modelPath, value) {
     fluid.componentForPath(componentPath).applier.change(modelPath, value);
 };
 
-gpii.test.nexus.changeEventForComponent = function (path) {
+fluid.test.nexus.changeEventForComponent = function (path) {
     return fluid.componentForPath(path).applier.modelChanged;
 };
 
 // Tests
 
-fluid.defaults("gpii.tests.nexus.recipeProductTestTree", {
+fluid.defaults("fluid.tests.nexus.recipeProductTestTree", {
     gradeNames: ["fluid.test.testEnvironment"],
     components: {
         recipeProductTester: {
-            type: "gpii.tests.nexus.recipeProductTester"
+            type: "fluid.tests.nexus.recipeProductTester"
         }
     }
 });
 
-fluid.defaults("gpii.tests.nexus.recipeProductTester", {
+fluid.defaults("fluid.tests.nexus.recipeProductTester", {
     gradeNames: ["fluid.test.testCaseHolder"],
     modules: [ {
         name: "Nexus Recipe Product tests",
@@ -70,7 +69,7 @@ fluid.defaults("gpii.tests.nexus.recipeProductTester", {
                         args: [
                             "nexusRecipeProductTests.componentA1",
                             {
-                                type: "gpii.test.nexus.reactantA"
+                                type: "fluid.test.nexus.reactantA"
                             }
                         ]
                     },
@@ -79,7 +78,7 @@ fluid.defaults("gpii.tests.nexus.recipeProductTester", {
                         args: [
                             "nexusRecipeProductTests.componentA2",
                             {
-                                type: "gpii.test.nexus.reactantA"
+                                type: "fluid.test.nexus.reactantA"
                             }
                         ]
                     },
@@ -88,7 +87,7 @@ fluid.defaults("gpii.tests.nexus.recipeProductTester", {
                         args: [
                             "nexusRecipeProductTests.componentB1",
                             {
-                                type: "gpii.test.nexus.reactantB"
+                                type: "fluid.test.nexus.reactantB"
                             }
                         ]
                     },
@@ -97,7 +96,7 @@ fluid.defaults("gpii.tests.nexus.recipeProductTester", {
                         args: [
                             "nexusRecipeProductTests.componentB2",
                             {
-                                type: "gpii.test.nexus.reactantB"
+                                type: "fluid.test.nexus.reactantB"
                             }
                         ]
                     },
@@ -107,7 +106,7 @@ fluid.defaults("gpii.tests.nexus.recipeProductTester", {
                         args: [
                             "nexusRecipeProductTests.recipeX1",
                             {
-                                type: "gpii.test.nexus.recipeX.product",
+                                type: "fluid.test.nexus.recipeX.product",
                                 componentPaths: {
                                     componentA: "nexusRecipeProductTests.componentA1",
                                     componentB: "nexusRecipeProductTests.componentB1"
@@ -119,7 +118,7 @@ fluid.defaults("gpii.tests.nexus.recipeProductTester", {
                         args: [
                             "nexusRecipeProductTests.recipeX2",
                             {
-                                type: "gpii.test.nexus.recipeX.product",
+                                type: "fluid.test.nexus.recipeX.product",
                                 componentPaths: {
                                     componentA: "nexusRecipeProductTests.componentA2",
                                     componentB: "nexusRecipeProductTests.componentB2"
@@ -129,11 +128,11 @@ fluid.defaults("gpii.tests.nexus.recipeProductTester", {
                     },
                     // Exercise the model relay rules and verify
                     {
-                        func: "gpii.test.nexus.changeModelAtPath",
+                        func: "fluid.test.nexus.changeModelAtPath",
                         args: ["nexusRecipeProductTests.componentA1", "valueA", 42]
                     },
                     {
-                        changeEvent: "@expand:gpii.test.nexus.changeEventForComponent(nexusRecipeProductTests.componentB1)",
+                        changeEvent: "@expand:fluid.test.nexus.changeEventForComponent(nexusRecipeProductTests.componentB1)",
                         path: "valueB",
                         listener: "jqUnit.assertEquals",
                         args: [
@@ -143,11 +142,11 @@ fluid.defaults("gpii.tests.nexus.recipeProductTester", {
                         ]
                     },
                     {
-                        func: "gpii.test.nexus.changeModelAtPath",
+                        func: "fluid.test.nexus.changeModelAtPath",
                         args: ["nexusRecipeProductTests.componentA2", "valueA", 420]
                     },
                     {
-                        changeEvent: "@expand:gpii.test.nexus.changeEventForComponent(nexusRecipeProductTests.componentB2)",
+                        changeEvent: "@expand:fluid.test.nexus.changeEventForComponent(nexusRecipeProductTests.componentB2)",
                         path: "valueB",
                         listener: "jqUnit.assertEquals",
                         args: [
@@ -162,4 +161,4 @@ fluid.defaults("gpii.tests.nexus.recipeProductTester", {
     } ]
 });
 
-fluid.test.runTests([ "gpii.tests.nexus.recipeProductTestTree" ]);
+fluid.test.runTests([ "fluid.tests.nexus.recipeProductTestTree" ]);

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/GPII/co-occurrence-engine/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/co-occurrence-engine/master/LICENSE.txt
 */
 
 /* eslint-env node */

--- a/tests/configs/fluid.tests.nexusWithCoOccurrenceEngine.config.json
+++ b/tests/configs/fluid.tests.nexusWithCoOccurrenceEngine.config.json
@@ -1,5 +1,5 @@
 {
-    "type": "gpii.tests.nexus.config",
+    "type": "fluid.tests.nexus.config",
     "options": {
         "serverPort": 8082,
         "components": {
@@ -10,10 +10,10 @@
                     "port": "{kettle.config}.options.serverPort",
                     "components": {
                         "nexus": {
-                            "type": "gpii.nexus.nexusWithCoOccurrenceEngine",
+                            "type": "fluid.nexus.nexusWithCoOccurrenceEngine",
                             "options": {
                                 "gradeNames": [
-                                    "gpii.tests.nexus.nexusWithCoOccurrenceEngine",
+                                    "fluid.tests.nexus.nexusWithCoOccurrenceEngine",
                                     "fluid.resolveRoot"
                                 ],
                                 "events": {
@@ -24,11 +24,11 @@
                                         "target": "{that coOccurrenceEngine}.options.listeners",
                                         "record": {
                                             "onComponentCreated": {
-                                                "funcName": "gpii.tests.nexus.coOccurrenceEngine.fireComponentGradeEvent",
+                                                "funcName": "fluid.tests.nexus.coOccurrenceEngine.fireComponentGradeEvent",
                                                 "args": [
                                                     "{arguments}.0",
                                                     {
-                                                        "gpii.test.nexus.recipeX.product": "{gpii.tests.nexus.nexusWithCoOccurrenceEngine}.events.onRecipeXProductCreated"
+                                                        "fluid.test.nexus.recipeX.product": "{fluid.tests.nexus.nexusWithCoOccurrenceEngine}.events.onRecipeXProductCreated"
                                                     }
                                                 ]
                                             }


### PR DESCRIPTION
Please note that this pull request does not update the version of the Nexus that the Co-Occurrence Engine depends on. Therefore, the code still contains some references to `gpi.nexus`: the functions and grades that the Co-Occurrence Engine uses from Nexus.

I'd like to tackle updating to the latest Nexus as another piece of work.
